### PR TITLE
show the slide in Chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
   <body>
     <textarea id="source">
     </textarea>
-    <script src="https://raw.githubusercontent.com/gnab/remark/v0.9.1/out/remark.min.js" type="text/javascript"></script>
+    <script src="https://gnab.github.io/remark/downloads/remark-latest.min.js" type="text/javascript"></script>
     <script type="text/javascript">
       var search = document.location.search;
       var volume = search.replace(/[&?]volume=([^&]+)/, function($0, $1){ return $1 });


### PR DESCRIPTION
Chrome refuse to execute `remark.js` with MIME type ('text/plain').
